### PR TITLE
Fix metrics graph display bug

### DIFF
--- a/models/sprint.py
+++ b/models/sprint.py
@@ -75,8 +75,7 @@ class SprintReadOnly:
 
     @staticmethod
     def percent(df, col_a, col_b):
-        df = df[col_a] / df[col_b]
-        df = df.map('{:.0%}'.format)
+        df = (df[col_a] / df[col_b]) * 100
         return df
 
     def mk_bau_breakdown_df(self):

--- a/views/sprints.py
+++ b/views/sprints.py
@@ -1,5 +1,6 @@
 import functools
 import dash_table
+from dash_table.Format import Format, Scheme, Symbol
 from functools import partial
 from itertools import chain
 import plotly.express as px
@@ -76,12 +77,24 @@ class Sprint:
             '# issues', '# delivered', '# bau',
             '% delivered', '% bau'
             ]]
+        cols = []
+        for i in df.columns[1:]:
+            col_spec = {
+                "name": i,
+                "id": i,
+                "type": "numeric"
+            }
+            if i.startswith('%'):
+                col_spec["format"] = Format(
+                    precision=0,
+                    scheme=Scheme.fixed,
+                    symbol=Symbol.yes,
+                    symbol_suffix='%')
+            cols.append(col_spec)
         fig = dash_table.DataTable(
-            columns=(
-                [{'name': '', "id": 'planned'}] +
-                [{'name': i, "id": i} for i in df.columns[1:]]),
+            columns=([{'name': '', "id": 'planned'}] + cols),
             data=df.to_dict('records'),
-            style_cell={'textAlign': 'left'},
+            style_cell={'textAlign': 'right'},
             style_as_list_view=True,
             style_data_conditional=[
                 {
@@ -487,6 +500,9 @@ class Metrics:
             margin=dict(t=20, b=20, r=0, l=0),
             )
         fig.update_layout(transition_duration=500)
+        for ax in fig['layout']:
+            if ax.startswith('yaxis'):
+                fig['layout'][ax]['ticksuffix'] = '%'
         return fig
 
     def render(self):


### PR DESCRIPTION
Because I stupidly hacked the underlying dataframe to
use formatted strings to display percentages the resulting
plots couldn't order the data correctly resulting in axis
with 10% above 80% for example.

The data is now numeric. And the views contain format config,
as it should be.